### PR TITLE
Modify Terraform configurations for bfv instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ my_tf_keypair.pub
 
 */terraform.tfstate
 */terraform.tfstate.backup
+
+my_keypair.json

--- a/2_instance_localnet/TF_VARiables
+++ b/2_instance_localnet/TF_VARiables
@@ -1,4 +1,7 @@
-export TF_VAR_keypair_name="my_tf_keypair"
+export TF_VAR_instance_name="my_tf_instance"
+export TF_VAR_instance_flavor="b.1c1gb"
+export TF_VAR_image_name="Ubuntu 22.04 Jammy Jellyfish x86_64"
+export TF_VAR_boot_vol_capacity=16
 export TF_VAR_network_name="my_tf_network"
 export TF_VAR_subnet_name="my_tf_subnet"
-export TF_VAR_instance_name="my_tf_instance"
+export TF_VAR_keypair_name="my_tf_keypair"

--- a/2_instance_localnet/deploy.tf
+++ b/2_instance_localnet/deploy.tf
@@ -15,12 +15,27 @@ resource "openstack_networking_subnet_v2" "subnet" {
   dns_nameservers = ["1.1.1.1", "9.9.9.9"]
 }
 
+data "openstack_images_image_v2" "image" {
+  name = var.image_name
+  most_recent = true
+}
+
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
-  image_name = var.image
-  flavor_name = var.flavor
+  flavor_name = var.instance_flavor
+
+  block_device {
+    uuid                  = data.openstack_images_image_v2.image.id
+    source_type           = "image"
+    volume_size           = var.boot_vol_capacity
+    boot_index            = 0
+    destination_type      = "volume"
+    delete_on_termination = true
+  }
+
   user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
+
   network {
     uuid = openstack_networking_network_v2.network.id
   }

--- a/2_instance_localnet/variables.tf
+++ b/2_instance_localnet/variables.tf
@@ -14,13 +14,14 @@ variable "instance_name" {
   type = string
 }
 
-variable "image" {
+variable "image_name" {
   type = string
-  default = "Ubuntu 22.04 Jammy Jellyfish x86_64"
 }
 
-variable "flavor" {
+variable "instance_flavor" {
   type = string
-  default = "2C-2GB-20GB"
 }
 
+variable "boot_vol_capacity" {
+  type = number
+}

--- a/3_instance_fullnet/TF_VARiables
+++ b/3_instance_fullnet/TF_VARiables
@@ -1,7 +1,10 @@
-export TF_VAR_keypair_name="my_tf_keypair"
+export TF_VAR_instance_name="my_tf_instance"
+export TF_VAR_instance_flavor="b.1c1gb"
+export TF_VAR_image_name="Ubuntu 22.04 Jammy Jellyfish x86_64"
+export TF_VAR_boot_vol_capacity=16
 export TF_VAR_network_name="my_tf_network"
 export TF_VAR_subnet_name="my_tf_subnet"
 export TF_VAR_router_name="my_tf_router"
 export TF_VAR_external_network="ext-net"
 export TF_VAR_secgroup_name="my_tf_secgroup"
-export TF_VAR_instance_name="my_tf_instance"
+export TF_VAR_keypair_name="my_tf_keypair"

--- a/3_instance_fullnet/variables.tf
+++ b/3_instance_fullnet/variables.tf
@@ -18,21 +18,23 @@ variable "secgroup_name" {
   type = string
 }
 
-variable "instance_name" {
-  type = string
-}
-
 variable external_network {
   type = string
   default = "ext-net"
 }
 
-variable "image" {
+variable "instance_name" {
   type = string
-  default = "Ubuntu 22.04 Jammy Jellyfish x86_64"
 }
 
-variable "flavor" {
+variable "image_name" {
   type = string
-  default = "2C-2GB-20GB"
+}
+
+variable "instance_flavor" {
+  type = string
+}
+
+variable "boot_vol_capacity" {
+  type = number
 }


### PR DESCRIPTION
In the openstack_compute_instance_v2 resource, we now define a block device as a boot volume of fixed size. And since we need the UUID of the image the instance uses, we take advantage of the
openstack_images_image_v2 data source. Finally, we introduce two new variables for setting the image name and the boot volume size.