### PR TITLE
Explicitly set visibility in openstack_images_image_v2

### DIFF
--- a/2_instance_localnet/deploy.tf
+++ b/2_instance_localnet/deploy.tf
@@ -17,6 +17,7 @@ resource "openstack_networking_subnet_v2" "subnet" {
 
 data "openstack_images_image_v2" "image" {
   name = var.image_name
+  visibility = "public"
   most_recent = true
 }
 

--- a/3_instance_fullnet/deploy.tf
+++ b/3_instance_fullnet/deploy.tf
@@ -53,6 +53,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
 
 data "openstack_images_image_v2" "image" {
   name = var.image_name
+  visibility = "public"
   most_recent = true
 }
 


### PR DESCRIPTION
We want the openstack_images_image_v2 data source to be looking explicitly for public images only, so we add the visibility = "public" directive.