### PR TITLE
Update data sources, configurations, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ my_tf_keypair.pub
 */terraform.tfstate.backup
 
 my_keypair.json
+my_instance.json
+my_instance_fip.json
+my_instance_list.json

--- a/2_instance_localnet/config.yaml
+++ b/2_instance_localnet/config.yaml
@@ -1,4 +1,0 @@
-#cloud-config
-
-package_update: true
-package_upgrade: true

--- a/2_instance_localnet/data.tf
+++ b/2_instance_localnet/data.tf
@@ -3,7 +3,3 @@ data "openstack_images_image_v2" "image" {
   visibility = "public"
   most_recent = true
 }
-
-data "openstack_networking_network_v2" "external_network" {
-  name = var.external_network
-}

--- a/2_instance_localnet/deploy.tf
+++ b/2_instance_localnet/deploy.tf
@@ -15,12 +15,6 @@ resource "openstack_networking_subnet_v2" "subnet" {
   dns_nameservers = ["1.1.1.1", "9.9.9.9"]
 }
 
-data "openstack_images_image_v2" "image" {
-  name = var.image_name
-  visibility = "public"
-  most_recent = true
-}
-
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
   flavor_name = var.instance_flavor
@@ -34,7 +28,6 @@ resource "openstack_compute_instance_v2" "instance" {
     delete_on_termination = true
   }
 
-  user_data = "${file("config.yaml")}"
   key_pair = openstack_compute_keypair_v2.keypair.name
 
   network {

--- a/3_instance_fullnet/deploy.tf
+++ b/3_instance_fullnet/deploy.tf
@@ -51,12 +51,6 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
   remote_ip_prefix = "0.0.0.0/0"
 }
 
-data "openstack_images_image_v2" "image" {
-  name = var.image_name
-  visibility = "public"
-  most_recent = true
-}
-
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
   flavor_name = var.instance_flavor


### PR DESCRIPTION
* move the data source for getting the image ID to a separate file (2_instance_localnet/data.tf)
* move config.yaml (cloud-init configuration) from 2_instance_localnet to the 3_instance_fullnet directory (this is where we create an instance with full internet access)
* augment 3_instance_fullnet/data.tf to contain a new data source for the name of a public-facing Cleura network
* update 2_instance_localnet/config.yaml and 3_instance_fullnet/data.tf configurations, reflecting the changes in corresponding data source files
* update .gitignore to list all check-point files we create during the tutorial