### PR TITLE
Deploy booting from an existing volume

### DIFF
--- a/2_instance_localnet/TF_VARiables
+++ b/2_instance_localnet/TF_VARiables
@@ -2,6 +2,7 @@ export TF_VAR_instance_name="my_tf_instance"
 export TF_VAR_instance_flavor="b.1c1gb"
 export TF_VAR_image_name="Ubuntu 22.04 Jammy Jellyfish x86_64"
 export TF_VAR_boot_vol_capacity=16
+export TF_VAR_boot_vol_name="my_tf_volume"
 export TF_VAR_network_name="my_tf_network"
 export TF_VAR_subnet_name="my_tf_subnet"
 export TF_VAR_keypair_name="my_tf_keypair"

--- a/2_instance_localnet/deploy.tf
+++ b/2_instance_localnet/deploy.tf
@@ -15,14 +15,23 @@ resource "openstack_networking_subnet_v2" "subnet" {
   dns_nameservers = ["1.1.1.1", "9.9.9.9"]
 }
 
+resource "openstack_blockstorage_volume_v3" "boot_volume" {
+  name = var.boot_vol_name
+  size = var.boot_vol_capacity
+  image_id = data.openstack_images_image_v2.image.id
+
+  lifecycle {
+    ignore_changes = [ image_id, ]
+  }
+}
+
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
   flavor_name = var.instance_flavor
 
   block_device {
-    uuid                  = data.openstack_images_image_v2.image.id
-    source_type           = "image"
-    volume_size           = var.boot_vol_capacity
+    uuid                  = openstack_blockstorage_volume_v3.boot_volume.id
+    source_type           = "volume"
     boot_index            = 0
     destination_type      = "volume"
     delete_on_termination = true

--- a/2_instance_localnet/variables.tf
+++ b/2_instance_localnet/variables.tf
@@ -25,3 +25,7 @@ variable "instance_flavor" {
 variable "boot_vol_capacity" {
   type = number
 }
+
+variable "boot_vol_name" {
+  type = string
+}

--- a/3_instance_fullnet/TF_VARiables
+++ b/3_instance_fullnet/TF_VARiables
@@ -2,6 +2,7 @@ export TF_VAR_instance_name="my_tf_instance"
 export TF_VAR_instance_flavor="b.1c1gb"
 export TF_VAR_image_name="Ubuntu 22.04 Jammy Jellyfish x86_64"
 export TF_VAR_boot_vol_capacity=16
+export TF_VAR_boot_vol_name="my_tf_volume"
 export TF_VAR_network_name="my_tf_network"
 export TF_VAR_subnet_name="my_tf_subnet"
 export TF_VAR_router_name="my_tf_router"

--- a/3_instance_fullnet/deploy.tf
+++ b/3_instance_fullnet/deploy.tf
@@ -51,14 +51,23 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
   remote_ip_prefix = "0.0.0.0/0"
 }
 
+resource "openstack_blockstorage_volume_v3" "boot_volume" {
+  name = var.boot_vol_name
+  size = var.boot_vol_capacity
+  image_id = data.openstack_images_image_v2.image.id
+
+  lifecycle {
+    ignore_changes = [ image_id, ]
+  }
+}
+
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
   flavor_name = var.instance_flavor
 
   block_device {
-    uuid                  = data.openstack_images_image_v2.image.id
-    source_type           = "image"
-    volume_size           = var.boot_vol_capacity
+    uuid                  = openstack_blockstorage_volume_v3.boot_volume.id
+    source_type           = "volume"
     boot_index            = 0
     destination_type      = "volume"
     delete_on_termination = true

--- a/3_instance_fullnet/variables.tf
+++ b/3_instance_fullnet/variables.tf
@@ -38,3 +38,7 @@ variable "instance_flavor" {
 variable "boot_vol_capacity" {
   type = number
 }
+
+variable "boot_vol_name" {
+  type = string
+}


### PR DESCRIPTION
Rather than defining the boot volume within the instance's `block_device`, define a separate volume resource and use that as the boot volume.
    
This way, we can set a `lifecycle` meta-argument on the boot volume and configure it to ignore changes to the image UUID.
    
This means that if we have an existing instance and the image is cycled so that a new image has the same name, but a different UUID, Terraform will not touch the boot volume and hence, will leave the instance alone as well. However, if we destroy the instance and then respin it, it boots from the new image.

