### PR TITLE
Set delete_on_termination flag to false

### DIFF
--- a/2_instance_localnet/deploy.tf
+++ b/2_instance_localnet/deploy.tf
@@ -34,7 +34,7 @@ resource "openstack_compute_instance_v2" "instance" {
     source_type           = "volume"
     boot_index            = 0
     destination_type      = "volume"
-    delete_on_termination = true
+    delete_on_termination = false
   }
 
   key_pair = openstack_compute_keypair_v2.keypair.name

--- a/3_instance_fullnet/deploy.tf
+++ b/3_instance_fullnet/deploy.tf
@@ -70,7 +70,7 @@ resource "openstack_compute_instance_v2" "instance" {
     source_type           = "volume"
     boot_index            = 0
     destination_type      = "volume"
-    delete_on_termination = true
+    delete_on_termination = false
   }
 
   user_data = "${file("config.yaml")}"


### PR DESCRIPTION
When Terraform has to re-create a server, for example, due to the user_data directive springing cloud-init into action, we do not want to re-create the boot volume of the server. Hence, in the block_device stanza of the openstack_compute_instance_v2 resource, we make sure to set the delete_on_termination flag to false.