### PR TITLE
Set ssh_deletekeys flag to false

### DIFF
--- a/3_instance_fullnet/config.yaml
+++ b/3_instance_fullnet/config.yaml
@@ -2,3 +2,5 @@
 
 package_update: true
 package_upgrade: true
+
+ssh_deletekeys: false


### PR DESCRIPTION
We do not want cloud-init deleting the SSH host key of the target instance, so in the cloud-init configuration file we explicitly set the ssh_deletekeys flag to false.