### PR TITLE
fix: Use version constraints for OpenStack provider

### DIFF
--- a/1_keypair/versions.tf
+++ b/1_keypair/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"

--- a/2_instance_localnet/versions.tf
+++ b/2_instance_localnet/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"

--- a/3_instance_fullnet/versions.tf
+++ b/3_instance_fullnet/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source = "terraform-provider-openstack/openstack"
+      version = "~> 1.53.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
While installing the OpenStack provider, we use the `~>` operator to request a version that is at least 1.53.0 and less than 1.54.0.
    
Without the version constraints, sometimes `tofu plan` would complain the resource `openstack_compute_floatingip_associate_v2` could not be found and abort.