### PR TITLE
Update templates to enable config_drive for server instances

### DIFF
--- a/2_instance_localnet/deploy.tf
+++ b/2_instance_localnet/deploy.tf
@@ -28,6 +28,7 @@ resource "openstack_blockstorage_volume_v3" "boot_volume" {
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
   flavor_name = var.instance_flavor
+  config_drive = true
 
   block_device {
     uuid                  = openstack_blockstorage_volume_v3.boot_volume.id

--- a/3_instance_fullnet/deploy.tf
+++ b/3_instance_fullnet/deploy.tf
@@ -70,6 +70,7 @@ resource "openstack_blockstorage_volume_v3" "boot_volume" {
 resource "openstack_compute_instance_v2" "instance" {
   name = var.instance_name
   flavor_name = var.instance_flavor
+  config_drive = true
 
   block_device {
     uuid                  = openstack_blockstorage_volume_v3.boot_volume.id


### PR DESCRIPTION
Update template to use config_drive instead of metadata service for instance configuration